### PR TITLE
fixes clickOutside rework

### DIFF
--- a/src/components/input/customInput.tsx
+++ b/src/components/input/customInput.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {BaseInput, IBaseInput} from './baseInput';
 import {SVG} from 'components/images/svgIcon';
-import {useOutsideClick} from 'hooks/clickOutside';
+import {useClickOutsideRef} from 'hooks/clickOutside';
 import './input.scss';
 
 export interface ICustomInput extends IBaseInput {
@@ -19,7 +19,7 @@ export function CustomInput(props: ICustomInput) {
   } = props;
 
   const [tooltipVisible, setTooltipVisible] = useState(false);
-  const ref = useOutsideClick(closeTooltip);
+  const ref = useClickOutsideRef<HTMLDivElement>(closeTooltip);
 
   function closeTooltip() {
     setTooltipVisible(false);

--- a/src/hooks/clickOutside.ts
+++ b/src/hooks/clickOutside.ts
@@ -1,9 +1,11 @@
 import {useEffect, useRef} from 'react';
 
-export function useOutsideClick (callback: () => void) {
-  const ref = useRef<HTMLDivElement>(null);
+export function useClickOutsideRef<T extends HTMLElement>(callback: () => void) {
+  const ref = useRef<T>(null);
 
   useEffect(() => {
+    if (!ref.current) return;
+
     function handleClickOutside (event: MouseEvent | TouchEvent) {
       if (ref.current && !ref.current.contains(event.target as Node)) {
         callback();
@@ -12,7 +14,6 @@ export function useOutsideClick (callback: () => void) {
 
     document.addEventListener('click', handleClickOutside);
     document.addEventListener('touchend', handleClickOutside);
-
 
     return () => {
       document.removeEventListener('click', handleClickOutside);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,5 @@ export {SVG} from './components/images/index';
 export {CustomInput, PasswordInput, PasswordRule} from './components/input/index';
 export {NotifyModal, QuestionModal} from './components/modal/index';
 
-export {useOutsideClick} from './hooks/index';
+export {useClickOutsideRef} from './hooks/index';
 export {PasswordRuleTypes} from './enums/index';


### PR DESCRIPTION
renames hook to useClickOutsideRef
fixes hook only being able to be used on div html elements 