### PR TITLE
*function executed after timeout should only be either callback or close

### DIFF
--- a/packages/src/components/modal/baseModal.tsx
+++ b/packages/src/components/modal/baseModal.tsx
@@ -34,9 +34,7 @@ export function BaseModal(props: IBaseModal) {
     if (!timeout) return;
 
     const t = setTimeout(() => {
-      callback && callback();
-
-      close();
+      return callback ? callback() : close();
     }, timeout);
 
     return () => clearTimeout(t);


### PR DESCRIPTION
Executed function in timeout should always be callback unless it is not provided, then it should fallback to the close function