### PR TITLE
*allows providing a number value for input components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "packages": {
       "name": "@hbuesing/ui-library",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "microbundle": "^0.15.1",

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@hbuesing/ui-library",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Collection of reusable ui components for react based applications",
   "source": "src/index.ts",
   "type": "module",

--- a/packages/src/components/input/baseInput.tsx
+++ b/packages/src/components/input/baseInput.tsx
@@ -4,7 +4,7 @@ import useInjectStyleSheet from 'utils/useInjectStyles';
 
 export interface IBaseInput extends ComponentPropsWithoutRef<'input'> {
   label       : string;
-  value       : string;
+  value       : string | number;
   valueChanged: (value: string) => void;
   iconColor?  : string;
   iconSrc?    : string;

--- a/packages/src/components/input/passwordInput.tsx
+++ b/packages/src/components/input/passwordInput.tsx
@@ -95,7 +95,7 @@ export function PasswordInput(props: IPasswordInput) {
     }
 
     const reg = new RegExp(pattern);
-    return reg.test(props.value);
+    return reg.test(props.value.toString());
   }
 
   return (


### PR DESCRIPTION
The default html input allows providing a number value. 
Previously it was only possible to provide string value for the custom input components 