### PR TITLE
toast component resturcture

### DIFF
--- a/packages/ui-library/src/components/toast/toast.tsx
+++ b/packages/ui-library/src/components/toast/toast.tsx
@@ -61,6 +61,8 @@ export function Toast(props: ToastProps) {
     >
       {message}
 
+      {action && <div>{action}</div>}
+
       {dismissible &&
         <button className={styles.closeButton} onClick={handleClose}>
           <svg ref={svgRef} xmlns={'http://www.w3.org/2000/svg'} viewBox={'0 0 384 512'}>
@@ -68,8 +70,6 @@ export function Toast(props: ToastProps) {
           </svg>
         </button>
       }
-
-      {action && <div>{action}</div>}
     </div>
   );
 }


### PR DESCRIPTION
moves the action component before the dismissable component.

This makes sure that the close button will always be at the end of the toast. Previously, user provided actions would always be the last element.