### PR TITLE
* fixes inputs being collapsed on focus, on the docs page

### DIFF
--- a/packages/ui-library/src/components/input/input.module.scss
+++ b/packages/ui-library/src/components/input/input.module.scss
@@ -10,6 +10,7 @@
     align-items: center;
     width: fit-content;
     max-width: 100%;
+    box-sizing: content-box;
 
     &.basic {
       border-bottom: 1px solid var(--uil-grey-dark);


### PR DESCRIPTION
Docs uses styling that seems to be overriding the behaviour for focused inputs, causing them to look collapsed